### PR TITLE
Join threads before showing summary

### DIFF
--- a/main.py
+++ b/main.py
@@ -207,8 +207,15 @@ class AutomationGUI(QMainWindow):
     def run_automation(self):
         self.post_manager.run()
         self.interaction_manager.run()
+
+        # wait for both managers to finish before showing results
+        if self.post_manager.thread:
+            self.post_manager.thread.join()
+        if self.interaction_manager.thread:
+            self.interaction_manager.thread.join()
+
         self.session_summary.show_summary()
-        QMessageBox.information(self, "Session Complete", "Automation completed successfully.")
+        QMessageBox.information(self, "Session Complete", "Automation tasks have completed.")
 
     def toggle_pause(self):
         if self.pause_btn.isChecked():


### PR DESCRIPTION
## Summary
- wait for post & interaction threads to finish before showing summary
- reflect finished status in completion message

## Testing
- `python -m py_compile main.py post_manager.py interaction_manager.py warmup_manager.py config_manager.py session_summary.py appium_driver.py`

------
https://chatgpt.com/codex/tasks/task_e_686ceefda1f48325bf4866e7f8bbd6c4