### PR TITLE
Add nickname editor via device list

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ class AutomationGUI(QMainWindow):
         layout.addWidget(QLabel("📱 Connected Devices:"))
 
         self.device_list = QListWidget()
+        self.device_list.itemDoubleClicked.connect(self.edit_nickname)
         layout.addWidget(self.device_list)
 
         refresh_btn = QPushButton("Refresh Devices")
@@ -62,6 +63,26 @@ class AutomationGUI(QMainWindow):
         for device in devices:
             nickname = self.config.devices.get(device, device)
             self.device_list.addItem(f"{nickname} ({device})")
+
+    def edit_nickname(self, item):
+        text = item.text()
+        device_id = text
+        current_nick = text
+        if '(' in text and text.endswith(')'):
+            name_part, id_part = text.rsplit('(', 1)
+            device_id = id_part[:-1]
+            current_nick = name_part.strip()
+
+        new_nick, ok = QInputDialog.getText(
+            self,
+            "Set Nickname",
+            f"Enter nickname for {device_id}:",
+            text=current_nick
+        )
+
+        if ok and new_nick:
+            self.config.update_nickname(device_id, new_nick)
+            self.refresh_devices()
 
     def accounts_tab(self):
         tab = QWidget()


### PR DESCRIPTION
## Summary
- enable editing a device nickname by double-clicking the device item
- store changes using `ConfigManager.update_nickname`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686cf16136d083259e18132733085449