### PR TITLE
Improve session summary using log_summary

### DIFF
--- a/session_summary.py
+++ b/session_summary.py
@@ -1,38 +1,23 @@
-import os
-import re
 from PyQt5.QtWidgets import QMessageBox
+from log_summary import accumulate_logs, format_duration
+
 
 class SessionSummary:
-    def __init__(self):
-        self.log_file = os.path.join("Logs", "automation_log.txt")
-        self.post_log = os.path.join("Logs", "post_log.txt")
-
     def show_summary(self):
-        """
-        Reads the automation log and displays a summary popup.
-        """
-        actions = {}
-        if os.path.exists(self.log_file):
-            with open(self.log_file, "r") as f:
-                for line in f:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    key = re.split(r':', line, 1)[0]
-                    actions[key] = actions.get(key, 0) + 1
-
-        if os.path.exists(self.post_log):
-            with open(self.post_log, "r") as f:
-                for line in f:
-                    if "SUCCESS" in line:
-                        key = line.split()[2]
-                        actions[key] = actions.get(key, 0) + 1
-
-        if actions:
-            parts = [f"{key}: {count} actions" for key, count in actions.items()]
-            summary_text = "\n".join(parts)
-        else:
+        """Read the log files and display a summary popup."""
+        counts, start, end = accumulate_logs()
+        if not counts:
             summary_text = "No logs found."
+        else:
+            header = f"{'Device':<15}{'Likes':>6}{'Follows':>8}{'Comments':>10}{'Shares':>8}{'Posts':>7}"
+            lines = [header, '-' * len(header)]
+            for device, data in counts.items():
+                lines.append(
+                    f"{device:<15}{data['likes']:>6}{data['follows']:>8}{data['comments']:>10}{data['shares']:>8}{data['posts']:>7}"
+                )
+            lines.append("")
+            lines.append(f"Session duration: {format_duration(start, end)}")
+            summary_text = "\n".join(lines)
 
         msg = QMessageBox()
         msg.setWindowTitle("Session Summary")


### PR DESCRIPTION
## Summary
- call `accumulate_logs` from `log_summary` instead of ad-hoc parsing
- show per-device counts in a table with overall session duration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686cfc2aa1e88325819c5d28649a2c0c