### PR TITLE
Add device ID log prefix

### DIFF
--- a/interaction_manager.py
+++ b/interaction_manager.py
@@ -68,7 +68,7 @@ class InteractionManager:
         # choose a random subset of actions each loop
         for action in random.sample(actions, k=random.randint(1, 4)):
             print(f"Performing {action} on {platform} account {account} for device {device_id}")
-            line = f"{time.asctime()}: {action.upper()} {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: {action.upper()} {platform} {account} on {device_id}\n"
             with open(log_path, "a") as log:
                 log.write(line)
             # here you’d call the driver’s methods, e.g. self.driver.swipe(...)

--- a/log_summary.py
+++ b/log_summary.py
@@ -30,12 +30,12 @@ def accumulate_logs():
     if os.path.exists(WARMUP_LOG):
         with open(WARMUP_LOG, "r") as f:
             for line in f:
-                m = re.match(r"(?P<ts>[A-Z][a-z]{2} [A-Z][a-z]{2}\s+\d+ \d+:\d+:\d+ \d{4}): Warmup (\w+) .* on (\S+)", line)
+                m = re.match(r"(?:\[(?P<prefix>[^\]]+)\]\s+)?(?P<ts>[A-Z][a-z]{2} [A-Z][a-z]{2}\s+\d+ \d+:\d+:\d+ \d{4}): Warmup (\w+) .* on (\S+)", line)
                 if not m:
                     continue
-                ts = parse_time(m.group("ts"))
-                action = m.group(2).upper()
-                device = m.group(3)
+                ts = parse_time(m.group('ts'))
+                action = m.group(3).upper()
+                device = m.group('prefix') or m.group(4)
                 metric = action_map.get(action)
                 if metric:
                     counts[device][metric] += 1
@@ -48,11 +48,11 @@ def accumulate_logs():
     if os.path.exists(POST_LOG):
         with open(POST_LOG, "r") as f:
             for line in f:
-                m = re.match(r"(?P<ts>[A-Z][a-z]{2} [A-Z][a-z]{2}\s+\d+ \d+:\d+:\d+ \d{4}): SUCCESS post \w+ \S+ on (\S+)", line)
+                m = re.match(r"(?:\[(?P<prefix>[^\]]+)\]\s+)?(?P<ts>[A-Z][a-z]{2} [A-Z][a-z]{2}\s+\d+ \d+:\d+:\d+ \d{4}): SUCCESS post \w+ \S+ on (\S+)", line)
                 if not m:
                     continue
-                ts = parse_time(m.group("ts"))
-                device = m.group(2)
+                ts = parse_time(m.group('ts'))
+                device = m.group('prefix') or m.group(3)
                 counts[device]["posts"] += 1
                 if ts:
                     if start_time is None or ts < start_time:

--- a/main.py
+++ b/main.py
@@ -267,12 +267,17 @@ class AutomationGUI(QMainWindow):
             return
 
         device_logs = {}
-        pattern = re.compile(r"on\s+([\w-]+)\b")
+        prefix_re = re.compile(r"^\[(\S+)\]")
+        suffix_re = re.compile(r"on\s+([\w-]+)\b")
         with open(log_file, "r") as f:
             for raw in f:
                 line = raw.strip()
-                match = pattern.search(line)
-                device = match.group(1) if match else "Unknown"
+                match = prefix_re.match(line)
+                if match:
+                    device = match.group(1)
+                else:
+                    match = suffix_re.search(line)
+                    device = match.group(1) if match else "Unknown"
                 device_logs.setdefault(device, []).append(line)
 
         self.logs_by_device = device_logs

--- a/post_manager.py
+++ b/post_manager.py
@@ -64,13 +64,13 @@ class PostManager:
         try:
             # Placeholder for draft posting logic
             print(f"Posting draft on {platform} account {account} for device {device_id}")
-            line = f"{time.asctime()}: SUCCESS post {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: SUCCESS post {platform} {account} on {device_id}\n"
             with open(log_path, "a") as log:
                 log.write(line)
             with open(automation_log, "a") as auto_log:
                 auto_log.write(line)
         except Exception as e:
-            line = f"{time.asctime()}: FAIL post {platform} {account} on {device_id}: {e}\n"
+            line = f"[{device_id}] {time.asctime()}: FAIL post {platform} {account} on {device_id}: {e}\n"
             with open(log_path, "a") as log:
                 log.write(line)
             with open(automation_log, "a") as auto_log:

--- a/warmup_manager.py
+++ b/warmup_manager.py
@@ -112,7 +112,7 @@ class WarmupManager:
         for _ in range(like_min):
             print(f"Warmup like on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup LIKE {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup LIKE {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Follows
@@ -120,7 +120,7 @@ class WarmupManager:
         for _ in range(follow_min):
             print(f"Warmup follow on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup FOLLOW {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup FOLLOW {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Comments
@@ -128,7 +128,7 @@ class WarmupManager:
         for _ in range(comment_min):
             print(f"Warmup comment on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup COMMENT {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup COMMENT {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Shares
@@ -136,7 +136,7 @@ class WarmupManager:
         for _ in range(share_min):
             print(f"Warmup share on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup SHARE {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup SHARE {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Story Views
@@ -144,7 +144,7 @@ class WarmupManager:
         for _ in range(view_min):
             print(f"Warmup story view on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup STORY_VIEW {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup STORY_VIEW {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Story Likes
@@ -152,7 +152,7 @@ class WarmupManager:
         for _ in range(like_story_min):
             print(f"Warmup story like on {platform} account {account} for device {device_id}")
             time.sleep(random.uniform(min_delay, max_delay))
-            line = f"{time.asctime()}: Warmup STORY_LIKE {platform} {account} on {device_id}\n"
+            line = f"[{device_id}] {time.asctime()}: Warmup STORY_LIKE {platform} {account} on {device_id}\n"
             append_logs(line)
 
         # Posts (if warmup day threshold reached)


### PR DESCRIPTION
## Summary
- include the device ID prefix in all warmup, posting and interaction logs
- update log summary parsing for new prefix
- parse device ID prefix in UI log viewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d01f2c99c83259c93ccdba35fb79b