### PR TITLE
Improve device table labels

### DIFF
--- a/main.py
+++ b/main.py
@@ -71,13 +71,27 @@ class AutomationGUI(QMainWindow):
         self.splitter.setHandleWidth(6)
         self.splitter.setStyleSheet("QSplitter::handle { background-color: #000; }")
 
-        self.iphone_table = QTableWidget()
-        self._setup_table(self.iphone_table)
         self.android_table = QTableWidget()
         self._setup_table(self.android_table)
+        self.iphone_table = QTableWidget()
+        self._setup_table(self.iphone_table)
 
-        self.splitter.addWidget(self.iphone_table)
-        self.splitter.addWidget(self.android_table)
+        android_container = QWidget()
+        android_layout = QVBoxLayout()
+        android_layout.setContentsMargins(0, 0, 0, 0)
+        android_layout.addWidget(QLabel("\ud83d\udcf1 Android Devices"))
+        android_layout.addWidget(self.android_table)
+        android_container.setLayout(android_layout)
+
+        iphone_container = QWidget()
+        iphone_layout = QVBoxLayout()
+        iphone_layout.setContentsMargins(0, 0, 0, 0)
+        iphone_layout.addWidget(QLabel("\ud83c\udf4f iPhone Devices"))
+        iphone_layout.addWidget(self.iphone_table)
+        iphone_container.setLayout(iphone_layout)
+
+        self.splitter.addWidget(android_container)
+        self.splitter.addWidget(iphone_container)
 
         layout.addWidget(self.splitter)
 
@@ -96,7 +110,8 @@ class AutomationGUI(QMainWindow):
         table.setColumnCount(3)
         table.setHorizontalHeaderLabels(["#", "Nickname", "Actions"])
         hdr = table.horizontalHeader()
-        hdr.setSectionResizeMode(QHeaderView.Stretch)
+        hdr.setSectionResizeMode(QHeaderView.Interactive)
+        hdr.setStretchLastSection(True)
         hdr.setDefaultAlignment(Qt.AlignCenter)
         table.verticalHeader().setVisible(False)
         table.setAlternatingRowColors(True)

--- a/utils.py
+++ b/utils.py
@@ -22,7 +22,9 @@ def format_last_activity(ts: float | None) -> str:
 
 
 def detect_device_os(device):
-    if "iPhone" in device.get('name', ''):
+    """Return the device OS based on name or id length."""
+    name = device.get("name", "")
+    dev_id = device.get("id", "")
+    if "iphone" in name.lower() or len(dev_id) == 40:
         return "iPhone"
-    else:
-        return "Android"
+    return "Android"


### PR DESCRIPTION
## Summary
- split device splitter into labeled Android/iPhone containers
- make column widths adjustable
- improve OS detection by checking device id length

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2f64286483258b2287069b9d2e3a