### PR TITLE
Improve OS detection for numeric device IDs

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,24 @@
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import utils
+
+
+def test_detect_device_os_iphone_by_name():
+    device = {"id": "123", "name": "My iPhone"}
+    assert utils.detect_device_os(device) == "iPhone"
+
+
+def test_detect_device_os_iphone_by_id():
+    device = {"id": "a" * 40, "name": "Device"}
+    assert utils.detect_device_os(device) == "iPhone"
+
+
+def test_detect_device_os_numeric_android():
+    device = {"id": "1" * 25, "name": "Android"}
+    assert utils.detect_device_os(device) == "Android"
+
+
+def test_detect_device_os_default_android():
+    device = {"id": "abcd1234", "name": "Pixel"}
+    assert utils.detect_device_os(device) == "Android"

--- a/utils.py
+++ b/utils.py
@@ -22,9 +22,21 @@ def format_last_activity(ts: float | None) -> str:
 
 
 def detect_device_os(device):
-    """Return the device OS based on name or id length."""
+    """Return the device OS based on name or id heuristics.
+
+    Devices whose name contains "iphone" (case-insensitive) or whose ID is a
+    40-character string are treated as iPhones.  Additionally, if the device ID
+    consists solely of digits and contains 20 or more characters, it is
+    classified as an Android device.
+    """
+
     name = device.get("name", "")
     dev_id = device.get("id", "")
+
     if "iphone" in name.lower() or len(dev_id) == 40:
         return "iPhone"
+
+    if dev_id.isdigit() and len(dev_id) >= 20:
+        return "Android"
+
     return "Android"


### PR DESCRIPTION
## Summary
- expand `detect_device_os` to identify Android devices whose IDs are 20+ digits
- add unit tests covering iPhone detection and numeric Android IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e320741ac83259536096d375ef46a