### PR TITLE
Simplify device OS detection

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,18 +4,13 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import utils
 
 
-def test_detect_device_os_iphone_by_name():
-    device = {"id": "123", "name": "My iPhone"}
+def test_detect_device_os_prefix_Z_is_iphone():
+    device = {"id": "Z12345", "name": "Phone"}
     assert utils.detect_device_os(device) == "iPhone"
 
 
-def test_detect_device_os_iphone_by_id():
-    device = {"id": "a" * 40, "name": "Device"}
-    assert utils.detect_device_os(device) == "iPhone"
-
-
-def test_detect_device_os_numeric_android():
-    device = {"id": "1" * 25, "name": "Android"}
+def test_detect_device_os_prefix_0_is_android():
+    device = {"id": "012345", "name": "Device"}
     assert utils.detect_device_os(device) == "Android"
 
 

--- a/utils.py
+++ b/utils.py
@@ -22,21 +22,19 @@ def format_last_activity(ts: float | None) -> str:
 
 
 def detect_device_os(device):
-    """Return the device OS based on name or id heuristics.
+    """Determine the device OS based on its ID prefix.
 
-    Devices whose name contains "iphone" (case-insensitive) or whose ID is a
-    40-character string are treated as iPhones.  Additionally, if the device ID
-    consists solely of digits and contains 20 or more characters, it is
-    classified as an Android device.
+    Devices whose ID starts with ``Z`` are considered iPhones while
+    IDs beginning with ``0`` are treated as Androids. Any other ID
+    defaults to Android.
     """
 
-    name = device.get("name", "")
     dev_id = device.get("id", "")
 
-    if "iphone" in name.lower() or len(dev_id) == 40:
+    if dev_id.startswith("Z"):
         return "iPhone"
 
-    if dev_id.isdigit() and len(dev_id) >= 20:
+    if dev_id.startswith("0"):
         return "Android"
 
     return "Android"


### PR DESCRIPTION
## Summary
- simplify the `detect_device_os` heuristic
- update tests for new device assignment rule

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e36d812f4832598e489e214a93934