### PR TITLE
Fix device OS detection

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,14 +4,14 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 import utils
 
 
-def test_detect_device_os_prefix_Z_is_iphone():
+def test_detect_device_os_prefix_Z_is_android():
     device = {"id": "Z12345", "name": "Phone"}
-    assert utils.detect_device_os(device) == "iPhone"
-
-
-def test_detect_device_os_prefix_0_is_android():
-    device = {"id": "012345", "name": "Device"}
     assert utils.detect_device_os(device) == "Android"
+
+
+def test_detect_device_os_prefix_0_is_iphone():
+    device = {"id": "012345", "name": "Device"}
+    assert utils.detect_device_os(device) == "iPhone"
 
 
 def test_detect_device_os_default_android():

--- a/utils.py
+++ b/utils.py
@@ -24,17 +24,17 @@ def format_last_activity(ts: float | None) -> str:
 def detect_device_os(device):
     """Determine the device OS based on its ID prefix.
 
-    Devices whose ID starts with ``Z`` are considered iPhones while
-    IDs beginning with ``0`` are treated as Androids. Any other ID
+    Devices whose ID starts with ``0`` are considered iPhones while
+    IDs beginning with ``Z`` are treated as Androids. Any other ID
     defaults to Android.
     """
 
     dev_id = device.get("id", "")
 
-    if dev_id.startswith("Z"):
+    if dev_id.startswith("0"):
         return "iPhone"
 
-    if dev_id.startswith("0"):
+    if dev_id.startswith("Z"):
         return "Android"
 
     return "Android"


### PR DESCRIPTION
## Summary
- classify iPhone IDs starting with `0`
- classify Android IDs starting with `Z`
- adjust unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686e3893c1208325ba9df4f79492addf