### PR TITLE
Fix account double-click handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -54,8 +54,8 @@ class ManageDialog(QDialog):
             table.verticalHeader().setVisible(False)
             table.setEditTriggers(QAbstractItemView.NoEditTriggers)
             table.itemDoubleClicked.connect(
-                lambda item, p=platform: self.gui.open_account_settings(
-                    self.device_id, p, item.text()
+                lambda item, p=platform, tbl=table: self.gui.open_account_settings(
+                    self.device_id, p, tbl.item(item.row(), 0).text()
                 )
             )
             self.tables[platform] = table


### PR DESCRIPTION
## Summary
- fix ManageDialog so clicking the Active column still opens the account settings for the correct username

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f102eba108325b43464aa1e1a9c66