### PR TITLE
Add GUI settings and config persistence tests

### DIFF
--- a/tests/test_apply_defaults.py
+++ b/tests/test_apply_defaults.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import random
+from PyQt5.QtWidgets import QApplication, QMessageBox
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import main
+from tests.test_manage_dialog import create_gui
+
+
+def test_apply_defaults_skips_warmup(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+    gui.config.add_device('dev1')
+    gui.config.add_account('dev1', 'TikTok', 'warm')
+    gui.config.add_account('dev1', 'Instagram', 'cold')
+
+    gui.config.settings['min_delay'] = 7
+    gui.config.settings['max_delay'] = 8
+    gui.config.settings['interaction_ranges'] = {'likes': [1, 1], 'daily_posts': [2, 2]}
+    gui.config.settings['draft_posts'] = True
+    gui.config.save_json(gui.config.settings_file, gui.config.settings)
+
+    monkeypatch.setattr(gui.warmup_manager, 'is_warmup_active', lambda u: u == 'warm')
+    monkeypatch.setattr(random, 'randint', lambda a, b: a)
+    monkeypatch.setattr(QMessageBox, 'information', lambda *a, **k: None)
+
+    gui.apply_defaults_to_all()
+
+    warm_settings = gui.config.get_account_settings('warm')
+    cold_settings = gui.config.get_account_settings('cold')
+
+    assert warm_settings == {}
+    assert cold_settings['min_delay'] == 7
+    assert cold_settings['max_delay'] == 8
+    assert cold_settings['likes'] == 1
+    assert cold_settings['daily_posts'] == 2
+    assert cold_settings['draft_posts'] is True
+
+    gui.close()
+    app.quit()

--- a/tests/test_config_manager.py
+++ b/tests/test_config_manager.py
@@ -47,6 +47,29 @@ def test_account_settings(tmp_path):
     assert settings['draft_posts'] is True
 
 
+def test_account_settings_persist_all_fields(tmp_path):
+    cm = create_cm(tmp_path)
+    all_settings = {
+        'min_delay': 1,
+        'max_delay': 2,
+        'likes': 3,
+        'follows': 4,
+        'comments': 5,
+        'shares': 6,
+        'saves': 7,
+        'watch_time': 8,
+        'scroll_duration': 9,
+        'story_interactions': 10,
+        'dms': 11,
+        'daily_posts': 12,
+        'draft_posts': True,
+    }
+    cm.set_account_settings('user1', all_settings)
+    cm2 = create_cm(tmp_path)
+    loaded = cm2.get_account_settings('user1')
+    assert loaded == all_settings
+
+
 def test_save_device_name(tmp_path):
     cm = create_cm(tmp_path)
     cm.add_device('dev1')

--- a/tests/test_manage_dialog.py
+++ b/tests/test_manage_dialog.py
@@ -37,3 +37,23 @@ def test_dialog_persists_accounts(tmp_path, monkeypatch):
     gui.close()
     app.quit()
 
+
+def test_double_click_opens_settings(tmp_path):
+    """Double clicking a username should open AccountSettingsWidget."""
+    gui, app = create_gui(tmp_path)
+    gui.config.add_device("dev1")
+    gui.config.add_account("dev1", "TikTok", "user1")
+
+    dialog = main.ManageDialog(gui, "dev1")
+    table = dialog.tables["TikTok"]
+    item = table.item(0, 0)
+    table.itemDoubleClicked.emit(item)
+
+    layout = gui.account_settings_area.layout()
+    widgets = [layout.itemAt(i).widget() for i in range(layout.count())]
+    assert any(isinstance(w, main.AccountSettingsWidget) for w in widgets)
+
+    dialog.close()
+    gui.close()
+    app.quit()
+


### PR DESCRIPTION
## Summary
- test opening account settings via double-click
- verify all account setting fields persist
- ensure global default application skips warmup accounts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3a48f4dc832597ac52e2e9b99aa2