### PR TITLE
Add platform filter for default application

### DIFF
--- a/main.py
+++ b/main.py
@@ -617,6 +617,14 @@ class AutomationGUI(QMainWindow):
         apply_btn.clicked.connect(self.apply_defaults_to_all)
         layout.addWidget(apply_btn)
 
+        apply_tiktok_btn = QPushButton("Apply to All TikTok Accounts")
+        apply_tiktok_btn.clicked.connect(lambda: self.apply_defaults_to_all({"TikTok"}))
+        layout.addWidget(apply_tiktok_btn)
+
+        apply_instagram_btn = QPushButton("Apply to All Instagram Accounts")
+        apply_instagram_btn.clicked.connect(lambda: self.apply_defaults_to_all({"Instagram"}))
+        layout.addWidget(apply_instagram_btn)
+
         tab.setLayout(layout)
         self.tabs.addTab(tab, "Settings")
 
@@ -644,11 +652,16 @@ class AutomationGUI(QMainWindow):
         self.config.settings['draft_posts'] = self.draft_checkbox.isChecked()
         self.config.save_json(self.config.settings_file, self.config.settings)
 
-    def apply_defaults_to_all(self):
+    def apply_defaults_to_all(self, platforms=None):
+        """Apply global defaults to all accounts optionally filtered by platform."""
         ranges = self.config.settings.get('interaction_ranges', {})
         applied = False
+        if platforms is not None:
+            platforms = set(platforms)
         for device in self.config.accounts.values():
-            for pdata in device.values():
+            for plat, pdata in device.items():
+                if platforms and plat not in platforms:
+                    continue
                 for username in pdata.get('accounts', []):
                     if self.warmup_manager.is_warmup_active(username):
                         continue
@@ -657,7 +670,9 @@ class AutomationGUI(QMainWindow):
                     settings['max_delay'] = self.config.settings.get('max_delay', 15)
                     for key, val in ranges.items():
                         if isinstance(val, list) and len(val) == 2:
-                            settings[key] = random.randint(val[0], val[1])
+                            settings[key] = val[1]
+                        else:
+                            settings[key] = val
                     settings['draft_posts'] = self.config.settings.get('draft_posts', False)
                     self.config.set_account_settings(username, settings)
                     applied = True

--- a/tests/test_apply_defaults.py
+++ b/tests/test_apply_defaults.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import random
 from PyQt5.QtWidgets import QApplication, QMessageBox
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -17,12 +16,11 @@ def test_apply_defaults_skips_warmup(tmp_path, monkeypatch):
 
     gui.config.settings['min_delay'] = 7
     gui.config.settings['max_delay'] = 8
-    gui.config.settings['interaction_ranges'] = {'likes': [1, 1], 'daily_posts': [2, 2]}
+    gui.config.settings['interaction_ranges'] = {'likes': [1, 5], 'daily_posts': [2, 7]}
     gui.config.settings['draft_posts'] = True
     gui.config.save_json(gui.config.settings_file, gui.config.settings)
 
     monkeypatch.setattr(gui.warmup_manager, 'is_warmup_active', lambda u: u == 'warm')
-    monkeypatch.setattr(random, 'randint', lambda a, b: a)
     monkeypatch.setattr(QMessageBox, 'information', lambda *a, **k: None)
 
     gui.apply_defaults_to_all()
@@ -33,9 +31,36 @@ def test_apply_defaults_skips_warmup(tmp_path, monkeypatch):
     assert warm_settings == {}
     assert cold_settings['min_delay'] == 7
     assert cold_settings['max_delay'] == 8
-    assert cold_settings['likes'] == 1
-    assert cold_settings['daily_posts'] == 2
+    assert cold_settings['likes'] == 5
+    assert cold_settings['daily_posts'] == 7
     assert cold_settings['draft_posts'] is True
+
+    gui.close()
+    app.quit()
+
+
+def test_apply_defaults_platform_filter(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+    gui.config.add_device('dev1')
+    gui.config.add_account('dev1', 'TikTok', 't_user')
+    gui.config.add_account('dev1', 'Instagram', 'i_user')
+
+    gui.config.settings['min_delay'] = 3
+    gui.config.settings['max_delay'] = 4
+    gui.config.settings['interaction_ranges'] = {'likes': [2, 9]}
+    gui.config.settings['draft_posts'] = False
+    gui.config.save_json(gui.config.settings_file, gui.config.settings)
+
+    monkeypatch.setattr(gui.warmup_manager, 'is_warmup_active', lambda u: False)
+    monkeypatch.setattr(QMessageBox, 'information', lambda *a, **k: None)
+
+    gui.apply_defaults_to_all({'TikTok'})
+
+    t_settings = gui.config.get_account_settings('t_user')
+    i_settings = gui.config.get_account_settings('i_user')
+
+    assert t_settings['likes'] == 9
+    assert i_settings == {}
 
     gui.close()
     app.quit()


### PR DESCRIPTION
## Summary
- implement platform filtering in `apply_defaults_to_all`
- copy global interaction values directly instead of randomizing
- expose platform-specific apply buttons in the global settings tab
- expand tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f50abd0e48325963cce704f3746ce