### PR TITLE
Change automation start order

### DIFF
--- a/main.py
+++ b/main.py
@@ -783,8 +783,8 @@ class AutomationGUI(QMainWindow):
         self.tabs.addTab(tab, "Start")
 
     def run_automation(self):
-        self.post_manager.run()
         self.interaction_manager.run()
+        self.post_manager.run()
 
         # wait for both managers to finish before showing results
         if self.post_manager.thread:


### PR DESCRIPTION
## Summary
- start InteractionManager before PostManager in `run_automation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f638faea88325873201e936563045