### PR TITLE
Add show_popup flag to apply_defaults_to_all

### DIFF
--- a/main.py
+++ b/main.py
@@ -652,8 +652,16 @@ class AutomationGUI(QMainWindow):
         self.config.settings['draft_posts'] = self.draft_checkbox.isChecked()
         self.config.save_json(self.config.settings_file, self.config.settings)
 
-    def apply_defaults_to_all(self, platforms=None):
-        """Apply global defaults to all accounts optionally filtered by platform."""
+    def apply_defaults_to_all(self, platforms=None, show_popup=True):
+        """Apply global defaults to all accounts optionally filtered by platform.
+
+        Parameters
+        ----------
+        platforms : iterable[str] | None
+            Optional set of platforms to limit updates to.
+        show_popup : bool, default True
+            Whether to display a confirmation popup when defaults are applied.
+        """
         ranges = self.config.settings.get('interaction_ranges', {})
         applied = False
         if platforms is not None:
@@ -676,7 +684,7 @@ class AutomationGUI(QMainWindow):
                     settings['draft_posts'] = self.config.settings.get('draft_posts', False)
                     self.config.set_account_settings(username, settings)
                     applied = True
-        if applied:
+        if applied and show_popup:
             QMessageBox.information(self, 'Defaults Applied', 'Global defaults applied to accounts without warmup.')
 
     def logs_tab(self):
@@ -783,6 +791,9 @@ class AutomationGUI(QMainWindow):
         self.tabs.addTab(tab, "Start")
 
     def run_automation(self):
+        # Apply global defaults to all accounts before starting managers
+        self.apply_defaults_to_all(show_popup=False)
+
         self.interaction_manager.run()
         self.post_manager.run()
 

--- a/tests/test_apply_defaults.py
+++ b/tests/test_apply_defaults.py
@@ -64,3 +64,46 @@ def test_apply_defaults_platform_filter(tmp_path, monkeypatch):
 
     gui.close()
     app.quit()
+
+
+def test_apply_defaults_no_popup(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+    gui.config.add_device('dev1')
+    gui.config.add_account('dev1', 'TikTok', 'user')
+
+    monkeypatch.setattr(gui.warmup_manager, 'is_warmup_active', lambda u: False)
+    called = []
+
+    def fake_info(*a, **k):
+        called.append(True)
+
+    monkeypatch.setattr(QMessageBox, 'information', fake_info)
+
+    gui.apply_defaults_to_all(show_popup=False)
+
+    assert not called
+
+    gui.close()
+    app.quit()
+
+
+def test_run_automation_applies_defaults(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+
+    recorded = {}
+
+    def fake_apply_defaults(platforms=None, show_popup=True):
+        recorded['show_popup'] = show_popup
+
+    monkeypatch.setattr(gui, 'apply_defaults_to_all', fake_apply_defaults)
+    monkeypatch.setattr(gui.session_summary, 'show_summary', lambda: None)
+    monkeypatch.setattr(gui.interaction_manager, 'run', lambda: None)
+    monkeypatch.setattr(gui.post_manager, 'run', lambda: None)
+    monkeypatch.setattr(QMessageBox, 'information', lambda *a, **k: None)
+
+    gui.run_automation()
+
+    assert recorded.get('show_popup') is False
+
+    gui.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- allow `AutomationGUI.apply_defaults_to_all` to skip the popup
- invoke `apply_defaults_to_all(show_popup=False)` in `run_automation`
- extend tests for the new flag and run_automation behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f655c1b588325b1d547a22fb98f1f