### PR TITLE
Add account switching on mismatch

### DIFF
--- a/appium_driver.py
+++ b/appium_driver.py
@@ -137,3 +137,25 @@ class AppiumDriver:
                 f"Account verification failed on {device_id} ({platform}): {e}"
             )
             return False
+
+    def switch_account(self, device_id, platform, username):
+        """Attempt to switch to ``username`` on ``device_id`` for ``platform``.
+
+        Logs the action and returns ``True`` if successful, ``False`` otherwise.
+        The actual switching steps are represented by placeholder actions.
+        """
+        try:
+            logger.info(
+                f"Switching account on {device_id} for platform {platform} to {username}"
+            )
+            # Placeholder for real account switching logic using Appium
+            time.sleep(1)
+            logger.info(
+                f"Successfully switched account on {device_id} to {username}"
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                f"Failed to switch account on {device_id} ({platform}) to {username}: {e}"
+            )
+            return False

--- a/interaction_manager.py
+++ b/interaction_manager.py
@@ -70,7 +70,14 @@ class InteractionManager:
             with open(log_path, "a") as log:
                 log.write(warning)
             print(warning.strip())
-            return
+            switched = self.driver.switch_account(device_id, platform, account)
+            result = "SUCCESS" if switched else "FAIL"
+            switch_line = f"[{device_id}] {time.asctime()}: SWITCH {result} {platform} {account} on {device_id}\n"
+            with open(log_path, "a") as log:
+                log.write(switch_line)
+            print(switch_line.strip())
+            if not switched:
+                return
 
         settings_override = self.config.get_account_settings(account)
         min_delay = settings_override.get("min_delay", self.config.settings.get("min_delay", 5))

--- a/post_manager.py
+++ b/post_manager.py
@@ -71,7 +71,14 @@ class PostManager:
             with open(automation_log, "a") as auto_log:
                 auto_log.write(warning)
             print(warning.strip())
-            return
+            switched = self.driver.switch_account(device_id, platform, account)
+            result = "SUCCESS" if switched else "FAIL"
+            switch_line = f"[{device_id}] {time.asctime()}: SWITCH {result} {platform} {account} on {device_id}\n"
+            with open(automation_log, "a") as auto_log:
+                auto_log.write(switch_line)
+            print(switch_line.strip())
+            if not switched:
+                return
         try:
             # Placeholder for draft posting logic
             print(f"Posting draft on {platform} account {account} for device {device_id}")

--- a/tests/test_switch_account.py
+++ b/tests/test_switch_account.py
@@ -1,0 +1,46 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from post_manager import PostManager
+from interaction_manager import InteractionManager
+
+class DummyDriver:
+    def __init__(self, verify_result=False):
+        self.verify_result = verify_result
+        self.switch_called = False
+    def verify_current_account(self, device_id, platform, username):
+        return self.verify_result
+    def switch_account(self, device_id, platform, username):
+        self.switch_called = True
+        return True
+
+class DummyConfig:
+    def __init__(self):
+        self.settings = {"min_delay": 0, "max_delay": 0}
+    def get_account_settings(self, username):
+        return {}
+    def update_last_activity(self, device_id, platform):
+        pass
+
+
+def test_post_manager_attempts_switch(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver()
+    config = DummyConfig()
+    pm = PostManager(driver, config)
+    pm.post_draft("dev", "TikTok", "user")
+    os.chdir(cwd)
+    assert driver.switch_called
+
+
+def test_interaction_manager_attempts_switch(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver()
+    config = DummyConfig()
+    im = InteractionManager(driver, config)
+    im.perform_interactions("dev", "TikTok", "user")
+    os.chdir(cwd)
+    assert driver.switch_called


### PR DESCRIPTION
## Summary
- add `switch_account` to the driver
- attempt account switch when a mismatch is detected
- log switch result before proceeding
- test that switching is attempted for posts and interactions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f6763dbd88325bb5a94320187e178