### PR TITLE
Add per-user log aggregation

### DIFF
--- a/session_summary.py
+++ b/session_summary.py
@@ -1,21 +1,39 @@
 from PyQt5.QtWidgets import QMessageBox
-from log_summary import accumulate_logs, format_duration
+from log_summary import accumulate_logs, accumulate_logs_by_account, format_duration
 
 
 class SessionSummary:
     def show_summary(self):
         """Read the log files and display a summary popup."""
-        counts, start, end = accumulate_logs()
-        if not counts:
+        device_counts, start_dev, end_dev = accumulate_logs()
+        user_counts, start_user, end_user = accumulate_logs_by_account()
+
+        if not device_counts and not user_counts:
             summary_text = "No logs found."
         else:
-            header = f"{'Device':<15}{'Likes':>6}{'Follows':>8}{'Comments':>10}{'Shares':>8}{'Posts':>7}"
-            lines = [header, '-' * len(header)]
-            for device, data in counts.items():
-                lines.append(
-                    f"{device:<15}{data['likes']:>6}{data['follows']:>8}{data['comments']:>10}{data['shares']:>8}{data['posts']:>7}"
-                )
-            lines.append("")
+            lines = []
+            if device_counts:
+                header = f"{'Device':<15}{'Likes':>6}{'Follows':>8}{'Comments':>10}{'Shares':>8}{'Posts':>7}"
+                lines.extend([header, '-' * len(header)])
+                for device, data in device_counts.items():
+                    lines.append(
+                        f"{device:<15}{data['likes']:>6}{data['follows']:>8}{data['comments']:>10}{data['shares']:>8}{data['posts']:>7}"
+                    )
+                lines.append("")
+
+            if user_counts:
+                header = f"{'Username':<15}{'Likes':>6}{'Follows':>8}{'Comments':>10}{'Shares':>8}{'Posts':>7}"
+                lines.extend([header, '-' * len(header)])
+                for user, data in user_counts.items():
+                    lines.append(
+                        f"{user:<15}{data['likes']:>6}{data['follows']:>8}{data['comments']:>10}{data['shares']:>8}{data['posts']:>7}"
+                    )
+                lines.append("")
+
+            start_times = [t for t in (start_dev, start_user) if t]
+            end_times = [t for t in (end_dev, end_user) if t]
+            start = min(start_times) if start_times else None
+            end = max(end_times) if end_times else None
             lines.append(f"Session duration: {format_duration(start, end)}")
             summary_text = "\n".join(lines)
 

--- a/tests/test_log_summary.py
+++ b/tests/test_log_summary.py
@@ -1,0 +1,29 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import log_summary
+
+
+def test_accumulate_logs_by_account(tmp_path):
+    log_dir = tmp_path / "Logs"
+    log_dir.mkdir()
+    log_file = log_dir / "automation_log.txt"
+    lines = [
+        "[dev1] Mon Jan 01 00:00:00 2024: LIKE TikTok user1 on dev1\n",
+        "[dev1] Mon Jan 01 00:01:00 2024: Warmup FOLLOW TikTok user1 on dev1\n",
+        "[dev2] Mon Jan 01 00:02:00 2024: COMMENT Instagram user2 on dev2\n",
+        "[dev1] Mon Jan 01 00:03:00 2024: SUCCESS post TikTok user1 on dev1\n",
+    ]
+    log_file.write_text("".join(lines))
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        counts, start, end = log_summary.accumulate_logs_by_account()
+    finally:
+        os.chdir(cwd)
+
+    assert counts["user1"]["likes"] == 1
+    assert counts["user1"]["follows"] == 1
+    assert counts["user1"]["posts"] == 1
+    assert counts["user2"]["comments"] == 1


### PR DESCRIPTION
## Summary
- extend `log_summary` with `accumulate_logs_by_account`
- show username totals in `SessionSummary`
- test username log parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f691fb3c08325bdec20ffbc783d16