### PR TITLE
Add app launch handling

### DIFF
--- a/interaction_manager.py
+++ b/interaction_manager.py
@@ -40,6 +40,8 @@ class InteractionManager:
                     platform_info = details.get(platform, {})
                     active_account = platform_info.get("active")
                     if active_account:
+                        self.driver.start_session(device_id, platform)
+                        self.driver.open_app(device_id, platform)
                         self.perform_interactions(device_id, platform, active_account)
                         # random delay between each account’s interactions
                         delay = random.uniform(

--- a/post_manager.py
+++ b/post_manager.py
@@ -55,6 +55,8 @@ class PostManager:
                     accounts = self.config.accounts.get(device_id, {}).get(platform, {})
                     active_account = accounts.get("active")
                     if active_account:
+                        self.driver.start_session(device_id, platform)
+                        self.driver.open_app(device_id, platform)
                         self.post_draft(device_id, platform, active_account)
                         delay = self._calculate_delay(active_account)
                         time.sleep(delay)

--- a/tests/test_switch_account.py
+++ b/tests/test_switch_account.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import time
+import threading
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from post_manager import PostManager
@@ -9,8 +11,18 @@ class DummyDriver:
     def __init__(self, verify_result=False):
         self.verify_result = verify_result
         self.switch_called = False
+        self.open_called = False
+        self.start_called = False
+
+    def start_session(self, device_id, platform):
+        self.start_called = True
+
+    def open_app(self, device_id, platform):
+        self.open_called = True
+
     def verify_current_account(self, device_id, platform, username):
         return self.verify_result
+
     def switch_account(self, device_id, platform, username):
         self.switch_called = True
         return True
@@ -18,8 +30,13 @@ class DummyDriver:
 class DummyConfig:
     def __init__(self):
         self.settings = {"min_delay": 0, "max_delay": 0}
+        self.accounts = {
+            "dev": {"TikTok": {"active": "user"}, "Instagram": {"active": None}}
+        }
+
     def get_account_settings(self, username):
         return {}
+
     def update_last_activity(self, device_id, platform):
         pass
 
@@ -43,4 +60,56 @@ def test_interaction_manager_attempts_switch(tmp_path):
     im = InteractionManager(driver, config)
     im.perform_interactions("dev", "TikTok", "user")
     os.chdir(cwd)
+    assert driver.switch_called
+
+
+def test_post_loop_invokes_open_and_switch(tmp_path, monkeypatch):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver()
+    config = DummyConfig()
+    pm = PostManager(driver, config)
+
+    from post_manager import time as pm_time
+    monkeypatch.setattr(pm_time, "sleep", lambda *a, **k: None)
+
+    original_post = pm.post_draft
+
+    def wrapped_post(*args, **kwargs):
+        original_post(*args, **kwargs)
+        pm.active = False
+
+    monkeypatch.setattr(pm, "post_draft", wrapped_post)
+
+    pm.active = True
+    pm._post_loop()
+    os.chdir(cwd)
+
+    assert driver.open_called
+    assert driver.switch_called
+
+
+def test_interaction_loop_invokes_open_and_switch(tmp_path, monkeypatch):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver()
+    config = DummyConfig()
+    im = InteractionManager(driver, config)
+
+    from interaction_manager import time as im_time
+    monkeypatch.setattr(im_time, "sleep", lambda *a, **k: None)
+
+    original_perform = im.perform_interactions
+
+    def wrapped_perform(*args, **kwargs):
+        original_perform(*args, **kwargs)
+        im.active = False
+
+    monkeypatch.setattr(im, "perform_interactions", wrapped_perform)
+
+    im.active = True
+    im._interaction_loop()
+    os.chdir(cwd)
+
+    assert driver.open_called
     assert driver.switch_called


### PR DESCRIPTION
## Summary
- extend `AppiumDriver` with `open_app`
- flesh out `switch_account` logic
- start a session and open the app in posting and interaction loops
- add tests for loop behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7b1048c083258050f5df4edab1fe