### PR TITLE
Add GUI preset unit test

### DIFF
--- a/tests/test_apply_defaults.py
+++ b/tests/test_apply_defaults.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import QApplication, QMessageBox
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 import main
+from config_manager import SLOW_HUMAN_PRESET
 from tests.test_manage_dialog import create_gui
 
 
@@ -104,6 +105,27 @@ def test_run_automation_applies_defaults(tmp_path, monkeypatch):
     gui.run_automation()
 
     assert recorded.get('show_popup') is False
+
+    gui.close()
+    app.quit()
+
+
+def test_apply_preset_populates_gui_and_settings(tmp_path):
+    gui, app = create_gui(tmp_path)
+
+    gui.apply_preset(SLOW_HUMAN_PRESET)
+
+    assert gui.config.settings["min_delay"] == SLOW_HUMAN_PRESET["min_delay"]
+    assert gui.min_delay_spin.value() == SLOW_HUMAN_PRESET["min_delay"]
+    likes_range = SLOW_HUMAN_PRESET["interaction_ranges"]["likes"]
+    stored_range = gui.config.settings["interaction_ranges"]["likes"]
+    spin_min = gui.range_spins["likes"][0].value()
+    spin_max = gui.range_spins["likes"][1].value()
+
+    assert stored_range == likes_range
+    assert spin_min == likes_range[0]
+    assert spin_max == likes_range[1]
+    assert gui.draft_checkbox.isChecked() == SLOW_HUMAN_PRESET["draft_posts"]
 
     gui.close()
     app.quit()


### PR DESCRIPTION
## Summary
- ensure `SLOW_HUMAN_PRESET` is imported in default tests
- verify preset application updates GUI and stored settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8482cc508325ae2860fd31dc6337