### PR TITLE
Implement open_first_draft and update post workflow

### DIFF
--- a/appium_driver.py
+++ b/appium_driver.py
@@ -217,3 +217,25 @@ class AppiumDriver:
                 f"Failed to switch account on {device_id} ({platform}) to {username}: {e}"
             )
             return False
+
+    def open_first_draft(self, device_id, platform):
+        """Open the first draft available for posting on the device."""
+        try:
+            logger.info(
+                f"Opening first draft on {device_id} for platform {platform}"
+            )
+            os_type = utils.detect_os(device_id)
+            if os_type == "Android":
+                subprocess.check_call(["adb", "-s", device_id, "shell", "input", "tap", "200", "200"])
+                time.sleep(0.5)
+                subprocess.check_call(["adb", "-s", device_id, "shell", "input", "tap", "200", "400"])
+            else:
+                subprocess.check_call(["idevicescreenshot", "-u", device_id, "/dev/null"])
+                time.sleep(0.5)
+            logger.info(f"First draft opened on {device_id}")
+            return True
+        except Exception as e:
+            logger.warning(
+                f"Failed to open first draft on {device_id} ({platform}): {e}"
+            )
+            return False

--- a/post_manager.py
+++ b/post_manager.py
@@ -82,6 +82,7 @@ class PostManager:
             if not switched:
                 return
         try:
+            self.driver.open_first_draft(device_id, platform)
             # Placeholder for draft posting logic
             print(f"Posting draft on {platform} account {account} for device {device_id}")
             line = f"[{device_id}] {time.asctime()}: SUCCESS post {platform} {account} on {device_id}\n"

--- a/tests/test_switch_account.py
+++ b/tests/test_switch_account.py
@@ -12,6 +12,7 @@ class DummyDriver:
         self.verify_result = verify_result
         self.switch_called = False
         self.open_called = False
+        self.open_draft_called = False
         self.start_called = False
 
     def start_session(self, device_id, platform):
@@ -19,6 +20,9 @@ class DummyDriver:
 
     def open_app(self, device_id, platform):
         self.open_called = True
+
+    def open_first_draft(self, device_id, platform):
+        self.open_draft_called = True
 
     def verify_current_account(self, device_id, platform, username):
         return self.verify_result
@@ -87,6 +91,19 @@ def test_post_loop_invokes_open_and_switch(tmp_path, monkeypatch):
 
     assert driver.open_called
     assert driver.switch_called
+
+
+def test_post_draft_invokes_open_first_draft(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver(verify_result=True)
+    config = DummyConfig()
+    pm = PostManager(driver, config)
+
+    pm.post_draft("dev", "TikTok", "user")
+    os.chdir(cwd)
+
+    assert driver.open_draft_called
 
 
 def test_interaction_loop_invokes_open_and_switch(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add `AppiumDriver.open_first_draft` placeholder implementation
- call new method from `PostManager.post_draft`
- extend dummy driver in tests and verify `open_first_draft` is called

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8644019883259ef3a88a8dca398f