### PR TITLE
Enhance warmup switch account logic

### DIFF
--- a/tests/test_switch_account.py
+++ b/tests/test_switch_account.py
@@ -6,6 +6,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from post_manager import PostManager
 from interaction_manager import InteractionManager
+import warmup_manager
 
 class DummyDriver:
     def __init__(self, verify_result=False):
@@ -129,4 +130,18 @@ def test_interaction_loop_invokes_open_and_switch(tmp_path, monkeypatch):
     os.chdir(cwd)
 
     assert driver.open_called
+    assert driver.switch_called
+
+
+def test_warmup_manager_attempts_switch(tmp_path):
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    driver = DummyDriver()
+    config = DummyConfig()
+    wm = warmup_manager.WarmupManager(driver, config)
+
+    wm.perform_warmup_actions("dev", "TikTok", "user")
+
+    os.chdir(cwd)
+
     assert driver.switch_called

--- a/warmup_manager.py
+++ b/warmup_manager.py
@@ -112,11 +112,24 @@ class WarmupManager:
         os.makedirs(log_dir, exist_ok=True)
 
         if not self.driver.verify_current_account(device_id, platform, account):
-            warning = f"[{device_id}] {time.asctime()}: WARNING account mismatch for {platform} {account} on {device_id}\n"
+            warning = (
+                f"[{device_id}] {time.asctime()}: WARNING account mismatch for {platform} {account} on {device_id}\n"
+            )
             with open(automation_log, "a") as auto_log:
                 auto_log.write(warning)
             print(warning.strip())
-            return
+
+            switched = self.driver.switch_account(device_id, platform, account)
+            result = "SUCCESS" if switched else "FAIL"
+            switch_line = (
+                f"[{device_id}] {time.asctime()}: SWITCH {result} {platform} {account} on {device_id}\n"
+            )
+            with open(automation_log, "a") as auto_log:
+                auto_log.write(switch_line)
+            print(switch_line.strip())
+
+            if not switched:
+                return
 
         account_settings = self.config.get_account_settings(account)
         min_delay = account_settings.get("min_delay", min_delay)


### PR DESCRIPTION
## Summary
- switch accounts during warmup when current account verification fails
- log switch outcomes and stop warmup actions on failure
- test warmup switch behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f87fc53c083258fb1a8daa786c534