### PR TITLE
Improve testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,10 @@ The GUI allows you to manage devices, accounts and start automation workflows. C
 
 ## Running Tests
 
-Basic tests for the `ConfigManager` class are provided using `pytest`. To execute them:
+Basic tests for the `ConfigManager` class are provided using `pytest`. Running
+`pip install -r requirements.txt` installs all dependencies, including
+`pytest`. To execute the tests:
 
 ```bash
-pip install pytest  # if not already installed
 pytest
 ```


### PR DESCRIPTION
## Summary
- clarify that installing `requirements.txt` covers pytest
- remove redundant `pip install pytest` step in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f890aff8883258ae23e601ca3f7ff