### PR TITLE
Add PyQt5 and backend notes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,17 @@ The GUI allows you to manage devices, accounts and start automation workflows. C
 
 Basic tests for the `ConfigManager` class are provided using `pytest`. Running
 `pip install -r requirements.txt` installs all dependencies, including
-`pytest`. To execute the tests:
+`pytest` and `PyQt5`. If you only need the GUI test dependencies you can
+manually install PyQt5 with:
+
+```bash
+pip install PyQt5
+```
+
+GUI tests expect an X11 backend. In headless environments use the offscreen
+platform by setting `QT_QPA_PLATFORM=offscreen`.
+
+To execute the tests:
 
 ```bash
 pytest


### PR DESCRIPTION
## Summary
- show how to install PyQt5 for the test suite
- mention the need for an X11/offscreen backend for GUI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f95a6e2e483258bf8c774639c6061