### PR TITLE
Refactor settings, logs and start tabs into dialogs

### DIFF
--- a/tests/test_apply_defaults.py
+++ b/tests/test_apply_defaults.py
@@ -113,19 +113,20 @@ def test_run_automation_applies_defaults(tmp_path, monkeypatch):
 def test_apply_preset_populates_gui_and_settings(tmp_path):
     gui, app = create_gui(tmp_path)
 
-    gui.apply_preset(SLOW_HUMAN_PRESET)
+    dialog = main.SettingsDialog(gui)
+    dialog.apply_preset(SLOW_HUMAN_PRESET)
 
     assert gui.config.settings["min_delay"] == SLOW_HUMAN_PRESET["min_delay"]
-    assert gui.min_delay_spin.value() == SLOW_HUMAN_PRESET["min_delay"]
+    assert dialog.min_delay_spin.value() == SLOW_HUMAN_PRESET["min_delay"]
     likes_range = SLOW_HUMAN_PRESET["interaction_ranges"]["likes"]
     stored_range = gui.config.settings["interaction_ranges"]["likes"]
-    spin_min = gui.range_spins["likes"][0].value()
-    spin_max = gui.range_spins["likes"][1].value()
+    spin_min = dialog.range_spins["likes"][0].value()
+    spin_max = dialog.range_spins["likes"][1].value()
 
     assert stored_range == likes_range
     assert spin_min == likes_range[0]
     assert spin_max == likes_range[1]
-    assert gui.draft_checkbox.isChecked() == SLOW_HUMAN_PRESET["draft_posts"]
+    assert dialog.draft_checkbox.isChecked() == SLOW_HUMAN_PRESET["draft_posts"]
 
     gui.close()
     app.quit()

--- a/tests/test_manage_dialog.py
+++ b/tests/test_manage_dialog.py
@@ -49,9 +49,8 @@ def test_double_click_opens_settings(tmp_path):
     item = table.item(0, 0)
     table.itemDoubleClicked.emit(item)
 
-    layout = gui.account_settings_area.layout()
-    widgets = [layout.itemAt(i).widget() for i in range(layout.count())]
-    assert any(isinstance(w, main.AccountSettingsWidget) for w in widgets)
+    assert isinstance(gui.account_settings_dialog, main.AccountSettingsDialog)
+    assert isinstance(gui.account_settings_dialog.settings_widget, main.AccountSettingsWidget)
 
     dialog.close()
     gui.close()

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -13,15 +13,16 @@ from tests.test_manage_dialog import create_gui
 def test_apply_preset_updates_settings_and_ui(tmp_path):
     gui, app = create_gui(tmp_path)
 
-    gui.apply_preset(SLOW_HUMAN_PRESET)
+    dialog = main.SettingsDialog(gui)
+    dialog.apply_preset(SLOW_HUMAN_PRESET)
 
     assert gui.config.settings["min_delay"] == SLOW_HUMAN_PRESET["min_delay"]
-    assert gui.min_delay_spin.value() == SLOW_HUMAN_PRESET["min_delay"]
+    assert dialog.min_delay_spin.value() == SLOW_HUMAN_PRESET["min_delay"]
 
     likes_range = SLOW_HUMAN_PRESET["interaction_ranges"]["likes"]
     stored_range = gui.config.settings["interaction_ranges"]["likes"]
-    spin_min = gui.range_spins["likes"][0].value()
-    spin_max = gui.range_spins["likes"][1].value()
+    spin_min = dialog.range_spins["likes"][0].value()
+    spin_max = dialog.range_spins["likes"][1].value()
 
     assert stored_range == likes_range
     assert spin_min == likes_range[0]


### PR DESCRIPTION
## Summary
- simplify AutomationGUI initialization to only create the devices tab
- move account settings UI into a new `AccountSettingsDialog`
- create new dialog classes `SettingsDialog`, `LogsDialog` and `StartDialog`
- refactor open_account_settings to launch the new dialog
- update tests for the dialog-based UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68732d1fac0c83259e1d16225d164d02