### PR TITLE
Add settings save confirmations

### DIFF
--- a/main.py
+++ b/main.py
@@ -262,6 +262,7 @@ class AccountSettingsDialog(QDialog):
 
     def save(self):
         self.gui.config.set_account_settings(self.username, self.settings_widget.get_settings())
+        QMessageBox.information(self, "Settings Saved", "Account settings saved.")
 
 
 class SettingsDialog(QDialog):
@@ -365,6 +366,10 @@ class SettingsDialog(QDialog):
         apply_instagram_btn.clicked.connect(lambda: gui.apply_defaults_to_all({"Instagram"}))
         layout.addWidget(apply_instagram_btn)
 
+        save_btn = QPushButton("Save Settings")
+        save_btn.clicked.connect(self.save_settings)
+        layout.addWidget(save_btn)
+
     def toggle_fast_bot_mode(self):
         state = self.fast_bot_mode_btn.isChecked()
         self.gui.config.settings["fast_mode"] = state
@@ -403,6 +408,11 @@ class SettingsDialog(QDialog):
             max_spin.setValue(vals[1])
 
         self.draft_checkbox.setChecked(self.gui.config.settings.get("draft_posts", False))
+
+    def save_settings(self):
+        """Persist global settings and show confirmation."""
+        self.gui.config.save_json(self.gui.config.settings_file, self.gui.config.settings)
+        QMessageBox.information(self, "Settings Saved", "Global settings saved.")
 
 
 class LogsDialog(QDialog):

--- a/tests/test_save_confirmation.py
+++ b/tests/test_save_confirmation.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from PyQt5.QtWidgets import QApplication, QMessageBox
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import main
+from tests.test_manage_dialog import create_gui
+
+
+def test_account_settings_save_shows_popup(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+    gui.config.add_device("dev1")
+    gui.config.add_account("dev1", "TikTok", "user")
+
+    dialog = main.AccountSettingsDialog(gui, "dev1", "TikTok", "user")
+
+    called = {}
+
+    def fake_info(*args, **kwargs):
+        called["called"] = True
+
+    monkeypatch.setattr(main.QMessageBox, "information", fake_info)
+
+    dialog.settings_widget.likes_spin.setValue(5)
+    dialog.save()
+
+    assert called.get("called")
+    assert gui.config.get_account_settings("user")["likes"] == 5
+
+    dialog.close()
+    gui.close()
+    app.quit()
+
+
+def test_settings_dialog_save_shows_popup(tmp_path, monkeypatch):
+    gui, app = create_gui(tmp_path)
+
+    dialog = main.SettingsDialog(gui)
+
+    called = {}
+
+    def fake_info(*args, **kwargs):
+        called["called"] = True
+
+    monkeypatch.setattr(main.QMessageBox, "information", fake_info)
+
+    dialog.min_delay_spin.setValue(2)
+    dialog.save_settings()
+
+    assert called.get("called")
+    assert gui.config.settings["min_delay"] == 2
+
+    dialog.close()
+    gui.close()
+    app.quit()


### PR DESCRIPTION
## Summary
- confirm per-account settings save with QMessageBox
- allow global settings to be saved explicitly
- add `Save Settings` button and handler
- test confirmation dialogs for account and global settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68736b41d8308325abdaf0a00c1e1b4c